### PR TITLE
Increase LangChain recursion limit from 25 to 50

### DIFF
--- a/agents/src/starknetAgent.ts
+++ b/agents/src/starknetAgent.ts
@@ -367,9 +367,14 @@ export class StarknetAgent implements IAgent {
       throw new Error(`Can't use execute with agent_mode: ${this.currentMode}`);
     }
 
-    const result = await this.agentReactExecutor.invoke({
-      messages: input,
-    });
+    const result = await this.agentReactExecutor.invoke(
+      {
+        messages: input,
+      },
+      {
+        recursionLimit: 50,
+      }
+    );
 
     return result.messages[result.messages.length - 1].content;
   }
@@ -403,7 +408,12 @@ export class StarknetAgent implements IAgent {
         `Can't use execute call data with agent_mode: ${this.currentMode}`
       );
     }
-    const aiMessage = await this.agentReactExecutor.invoke({ messages: input });
+    const aiMessage = await this.agentReactExecutor.invoke(
+      { messages: input },
+      {
+        recursionLimit: 50,
+      }
+    );
     try {
       const parsedResult = JSON.parse(
         aiMessage.messages[aiMessage.messages.length - 2].content


### PR DESCRIPTION
## Problem
Our trading agent occasionally hits the default LangChain recursion limit of 25 when processing complex queries that require multiple tool calls and reasoning steps. This causes the agent to terminate prematurely without completing the requested analysis.

## Solution
This PR increases the recursion limit from the default 25 to 50 in the `execute` and `execute_call_data` methods of the `StarknetAgent` class by adding the `recursionLimit` parameter to the LangChain invoke configuration.

## Changes
- Modified `agents/src/starknetAgent.ts` to pass a `recursionLimit: 50` configuration parameter when invoking the agent
- Implemented the change for both regular agent execution and call data execution

## Testing
The change has been tested with complex queries that previously failed with the recursion limit error. With the increased limit, the agent is now able to complete these complex operations successfully.

## Notes
This is a configuration-only change with no modification to the agent's reasoning capabilities or output format. It simply allows the agent to take more recursive steps when needed for complex queries.

Closes #30 