### PR TITLE
Add support for Gemini 2.5 Flash Preview model

### DIFF
--- a/server/config/env.validation.ts
+++ b/server/config/env.validation.ts
@@ -49,6 +49,7 @@ const AI_PROVIDER_MODELS = {
     'gemini-1.5-pro-latest',
     'gemini-1.5-pro-001',
     'gemini-1.5-pro-002',
+    'gemini-2.5-flash-preview-04-17',
   ],
   ollama: [
     'llama3.3',


### PR DESCRIPTION
This PR adds support for Google's Gemini 2.5 Flash Preview model (`gemini-2.5-flash-preview-04-17`) to our trading agent.

## Changes
- Added `gemini-2.5-flash-preview-04-17` to the list of supported Gemini models in environment validation

## How to use
1. Set the following environment variables in your `.env` file:

AI_PROVIDER="gemini"
AI_MODEL="gemini-2.5-flash-preview-04-17"
AI_PROVIDER_API_KEY="your-google-gemini-api-key"

2. Restart the application

## Why
Gemini 2.5 Flash offers improved performance and reasoning capabilities compared to previous models, potentially enhancing our trading agent's decision-making process while maintaining reasonable costs.

## Testing
The change has been validated by confirming the model appears in the validation schema. To fully test, configure the environment variables as described above and verify the agent responds correctly.