### PR TITLE
 Add Gemini 2.5 Pro preview model support

### DIFF
--- a/server/config/env.validation.ts
+++ b/server/config/env.validation.ts
@@ -50,6 +50,10 @@ const AI_PROVIDER_MODELS = {
     'gemini-1.5-pro-001',
     'gemini-1.5-pro-002',
     'gemini-2.5-flash-preview-04-17',
+    'gemini-2.5-pro',
+    'gemini-2.5-pro-preview-05-06',
+    'gemini-2.5-pro-preview-03-25',
+    'gemini-2.5-pro-exp-03-25'
   ],
   ollama: [
     'llama3.3',


### PR DESCRIPTION
## Problem
- Gemini 2.5 Pro model was not found (404 error)
- Previous compatibility fix for JSON schemas needed to be tested with the newest models

## Solution
- Add support for Gemini 2.5 Pro preview/experimental model variants
- Added model identifiers to validation:
  - `gemini-2.5-pro-preview-05-06`
  - `gemini-2.5-pro-preview-03-25`
  - `gemini-2.5-pro-exp-03-25`

## Notes
- Verified that our JSON schema compatibility adapter works with these models
- Users can now choose the latest Pro models for better reasoning capabilities