### PR TITLE
Migrate from Paradex to LeftCurve API for Cryptocurrency Prices

### DIFF
--- a/plugins/leftcurve/src/interfaces/results.ts
+++ b/plugins/leftcurve/src/interfaces/results.ts
@@ -101,3 +101,20 @@ export interface ListMarketResponse {
     symbol: string;
   }>;
 }
+
+/**
+ * Structure pour stocker les données de prix en cache
+ */
+export interface CachedPrice {
+  price: number;
+  timestamp: number;
+  source: string;
+}
+
+/**
+ * Interface pour la réponse de l'API LeftCurve de prix
+ */
+export interface TokenPriceResponse {
+  canonicalSymbol: string;
+  priceUSD: number;
+}

--- a/plugins/leftcurve/src/services/PriceService.ts
+++ b/plugins/leftcurve/src/services/PriceService.ts
@@ -1,21 +1,5 @@
-import { BBOService } from '../actions/paradexActions/getBBO.js';
 import { SystemConfig } from '../interfaces/config.js';
-import { BBOResponse } from '../interfaces/results.js';
-import { validateSupportedToken, getMarketsForToken } from '../utils/validateSupportedToken.js';
-
-// Structure pour stocker les données de prix en cache
-interface CachedPrice {
-  price: number;
-  timestamp: number;
-  source: string;
-}
-
-// Types de marché disponibles
-enum MarketFormat {
-  PERP = '{SYMBOL}-USD-PERP',
-  SPOT = '{SYMBOL}-USD',
-  BTC = '{SYMBOL}-BTC',
-}
+import { CachedPrice, TokenPriceResponse } from '../interfaces/results.js';
 
 // Définit des plages de prix valides pour les tokens majeurs
 interface PriceRange {
@@ -27,7 +11,12 @@ interface PriceRange {
 export class PriceService {
   private static instance: PriceService;
   private priceCache: Map<string, CachedPrice> = new Map();
-  private bboService: BBOService;
+  
+  // URL de l'API LeftCurve pour les prix
+  private PRICE_API_URL = 'http://13.38.118.193:8080/api/token-master/prices/by-symbols/';
+  
+  // Clé API pour accéder à l'API LeftCurve
+  private API_KEY = 'WcmZV.MLUM69s@pDNwwxbLTiH';
   
   // Durée maximale de validité du cache en millisecondes (30 minutes)
   private CACHE_EXPIRY_MS = 30 * 60 * 1000;
@@ -38,13 +27,6 @@ export class PriceService {
   // Délai entre les tentatives (en millisecondes)
   private RETRY_DELAY_MS = 1000;
   
-  // Liste des formats de marché à essayer dans l'ordre
-  private marketFormats: MarketFormat[] = [
-    MarketFormat.PERP,
-    MarketFormat.SPOT,
-    MarketFormat.BTC,
-  ];
-
   // Définir un prix par défaut pour certains tokens connus (en USD)
   private defaultPrices: Record<string, number> = {
     'USDC': 1,
@@ -56,24 +38,15 @@ export class PriceService {
   // Définit des plages de prix acceptables pour des tokens majeurs
   // Utilisé pour filtrer les prix manifestement incorrects
   private tokenPriceRanges: Record<string, PriceRange> = {
-    'BTC': { min: 20000, max: 200000, typical: 100000 },
-    'ETH': { min: 1000, max: 10000, typical: 3000 },
-    'SOL': { min: 20, max: 500, typical: 150 },
-    'DOGE': { min: 0.05, max: 1, typical: 0.15 },
-    'AVAX': { min: 10, max: 200, typical: 40 },
-    'MATIC': { min: 0.3, max: 3, typical: 0.8 }
+    'BTC': { min: 20000, max: 500000, typical: 100000 },
+    'ETH': { min: 1000, max: 20000, typical: 3000 },
+    'SOL': { min: 20, max: 1000, typical: 150 },
+    'DOGE': { min: 0.05, max: 2, typical: 0.15 },
+    'AVAX': { min: 10, max: 500, typical: 40 },
+    'MATIC': { min: 0.3, max: 5, typical: 0.8 }
   };
-  
-  // Liste des sources de marché à exclure (options, marchés non fiables, etc.)
-  private excludedMarketPatterns: RegExp[] = [
-    /-USD-\d+-(C|P)$/, // Exclut les contrats d'options (call/put)
-    /-USDT$/,          // Préfère les paires en USD plutôt qu'en USDT
-    /-\d{5,}$/         // Exclut les marchés avec grands nombres (souvent des futures lointains)
-  ];
 
-  private constructor() {
-    this.bboService = new BBOService();
-  }
+  private constructor() {}
 
   /**
    * Obtient l'instance singleton du PriceService
@@ -89,13 +62,13 @@ export class PriceService {
   /**
    * Récupère le prix d'un token, avec gestion de cache et fallback
    * @param symbol Symbole du token (ex: "ETH", "BTC")
-   * @param config Configuration système pour l'API
+   * @param config Configuration système pour l'API (non utilisé avec la nouvelle API)
    * @param forceFresh Forcer le rafraîchissement du cache
    * @returns Prix en USD ou undefined si impossible à obtenir
    */
   public async getTokenPrice(
     symbol: string,
-    config: SystemConfig,
+    config?: SystemConfig,
     forceFresh = false
   ): Promise<number | undefined> {
     // Tokens stables connus
@@ -103,16 +76,7 @@ export class PriceService {
       return this.defaultPrices[symbol];
     }
     
-    // Check if the token is supported by Paradex before attempting to fetch price
     const symbolUpper = symbol.toUpperCase();
-    const tokenValidation = validateSupportedToken(symbolUpper);
-    
-    if (!tokenValidation.isSupported) {
-      console.error(`Token ${symbol} is not supported on Paradex. Cannot fetch price.`);
-      console.error(tokenValidation.message);
-      return undefined;
-    }
-
     const cacheKey = symbolUpper;
     const cachedData = this.priceCache.get(cacheKey);
 
@@ -134,7 +98,7 @@ export class PriceService {
     }
 
     // Essayer d'obtenir un prix frais
-    const freshPrice = await this.fetchFreshPrice(symbol, config);
+    const freshPrice = await this.fetchFreshPrice(symbolUpper);
     
     if (freshPrice !== undefined) {
       // Vérifier si le nouveau prix est raisonnable
@@ -211,10 +175,10 @@ export class PriceService {
       }
     }
     
-    // Pour les autres tokens, accepter des prix entre $0.00001 et $10,000
+    // Pour les autres tokens, accepter des prix entre $0.00001 et $100,000
     // (Plage très large pour les tokens sans référence spécifique)
-    if (price <= 0 || price > 10000) {
-      // Sauf pour BTC qui peut dépasser 10,000
+    if (price <= 0 || price > 100000) {
+      // Sauf pour BTC qui peut dépasser 100,000
       if (symbolUpper !== 'BTC' || price <= 0) {
         console.warn(`Price for ${symbol} ($${price}) is outside general acceptable range`);
         return false;
@@ -223,213 +187,62 @@ export class PriceService {
     
     return true;
   }
-  
-  /**
-   * Vérifie si une source de marché doit être exclue
-   * @param market Nom du marché
-   * @returns true si le marché doit être exclu
-   */
-  private shouldExcludeMarket(market: string): boolean {
-    // Vérifier si le marché correspond à l'un des patterns à exclure
-    for (const pattern of this.excludedMarketPatterns) {
-      if (pattern.test(market)) {
-        return true;
-      }
-    }
-    return false;
-  }
 
   /**
-   * Tente d'obtenir un prix frais en utilisant différentes méthodes
+   * Tente d'obtenir un prix frais en utilisant l'API LeftCurve
    * @param symbol Symbole du token
-   * @param config Configuration système
    * @returns Objet contenant le prix et sa source, ou undefined
    */
   private async fetchFreshPrice(
-    symbol: string,
-    config: SystemConfig
+    symbol: string
   ): Promise<{ price: number; source: string } | undefined> {
     const symbolUpper = symbol.toUpperCase();
     
-    // Check if we have known markets for this token in our cache
-    const knownMarkets = getMarketsForToken(symbolUpper);
-    if (knownMarkets && knownMarkets.length > 0) {
-      // Filtrer les marchés à exclure
-      const filteredMarkets = knownMarkets.filter(market => !this.shouldExcludeMarket(market));
-      
-      if (filteredMarkets.length > 0) {
-        console.log(`Using ${filteredMarkets.length} filtered markets for ${symbolUpper} (from ${knownMarkets.length} total markets)`);
-      } else {
-        console.warn(`⚠️ All ${knownMarkets.length} known markets for ${symbolUpper} were filtered out. Using original list.`);
-        // Si tous les marchés sont filtrés, utiliser la liste originale
-        // mais privilégier les marchés spot
-      }
-      
-      const marketsToUse = filteredMarkets.length > 0 ? filteredMarkets : knownMarkets;
-      
-      // Prioriser les marchés spot (sans suffixe -PERP ou autres)
-      const spotMarkets = marketsToUse.filter(m => m.includes('-USD') && !m.includes('-USD-'));
-      const perpMarkets = marketsToUse.filter(m => m.includes('-USD-PERP'));
-      const otherUsdMarkets = marketsToUse.filter(m => m.includes('-USD') && !spotMarkets.includes(m) && !perpMarkets.includes(m));
-      
-      // Ordre de priorité : spot > perp > autres USD > BTC
-      const prioritizedUsdMarkets = [...spotMarkets, ...perpMarkets, ...otherUsdMarkets];
-      
-      if (prioritizedUsdMarkets.length > 0) {
-        // Try each prioritized USD market
-        for (const market of prioritizedUsdMarkets) {
-          for (let attempt = 1; attempt <= this.MAX_RETRY_ATTEMPTS; attempt++) {
-            try {
-              const bboData = await this.bboService.fetchMarketBBO(config, market);
-              
-              if (bboData?.bid) {
-                const price = parseFloat(bboData.bid);
-                if (!isNaN(price) && price > 0) {
-                  console.log(`Got price for ${symbol} from market ${market}: $${price} (attempt ${attempt})`);
-                  
-                  // Vérifier que le prix est dans une plage raisonnable
-                  if (this.isPriceReasonable(symbolUpper, price)) {
-                    return { price, source: market };
-                  } else {
-                    console.warn(`⚠️ Rejected unreasonable price for ${symbol} from ${market}: $${price}`);
-                    // Continuer à chercher un prix plus raisonnable
-                  }
-                }
-              }
-              
-              if (!bboData?.bid && bboData?.ask) {
-                const askPrice = parseFloat(bboData.ask);
-                if (!isNaN(askPrice) && askPrice > 0) {
-                  const estimatedBid = askPrice * 0.995;
-                  console.log(`Using adjusted ask price for ${symbol} from market ${market}: $${estimatedBid} (from ask ${askPrice}, attempt ${attempt})`);
-                  
-                  // Vérifier que le prix estimé est dans une plage raisonnable
-                  if (this.isPriceReasonable(symbolUpper, estimatedBid)) {
-                    return { price: estimatedBid, source: `${market} (adjusted ask)` };
-                  } else {
-                    console.warn(`⚠️ Rejected unreasonable adjusted price for ${symbol} from ${market}: $${estimatedBid}`);
-                    // Continuer à chercher un prix plus raisonnable
-                  }
-                }
-              }
-            } catch (error) {
-              console.warn(`Error fetching market ${market} on attempt ${attempt}:`, error);
-              
-              if (attempt < this.MAX_RETRY_ATTEMPTS) {
-                await this.sleep(this.RETRY_DELAY_MS);
-              }
-            }
+    // Essayer d'obtenir le prix depuis l'API LeftCurve
+    for (let attempt = 1; attempt <= this.MAX_RETRY_ATTEMPTS; attempt++) {
+      try {
+        // Encodage du symbole pour l'URL
+        const encodedSymbol = encodeURIComponent(symbolUpper);
+        const apiUrl = `${this.PRICE_API_URL}${encodedSymbol}`;
+        
+        console.log(`Fetching price for ${symbolUpper} from LeftCurve API (attempt ${attempt}): ${apiUrl}`);
+        
+        const response = await fetch(apiUrl, {
+          headers: {
+            'Accept': 'application/json',
+            'api-key': this.API_KEY
           }
+        });
+        
+        if (!response.ok) {
+          throw new Error(`API returned status ${response.status}: ${response.statusText}`);
         }
-      }
-      
-      // Si USD markets ont échoué ou étaient déraisonnables, essayer BTC markets en dernier recours
-      const btcMarkets = marketsToUse.filter(m => m.includes('-BTC'));
-      if (btcMarkets.length > 0) {
-        // Récupérer le prix BTC de manière récursive, mais avec vérification pour éviter boucle infinie
-        if (symbolUpper !== 'BTC') {
-          const btcPrice = await this.getTokenPrice('BTC', config);
-          if (btcPrice && this.isPriceReasonable('BTC', btcPrice)) {
-            // Try each known BTC market
-            for (const market of btcMarkets) {
-              for (let attempt = 1; attempt <= this.MAX_RETRY_ATTEMPTS; attempt++) {
-                try {
-                  const bboData = await this.bboService.fetchMarketBBO(config, market);
-                  
-                  if (bboData?.bid) {
-                    const priceBTC = parseFloat(bboData.bid);
-                    if (!isNaN(priceBTC) && priceBTC > 0) {
-                      const priceUSD = priceBTC * btcPrice;
-                      console.log(`Got price for ${symbol} from BTC market ${market}: ${priceBTC} BTC = $${priceUSD} (attempt ${attempt})`);
-                      
-                      // Vérifier que le prix converti est dans une plage raisonnable
-                      if (this.isPriceReasonable(symbolUpper, priceUSD)) {
-                        return { price: priceUSD, source: `${market} (via BTC)` };
-                      } else {
-                        console.warn(`⚠️ Rejected unreasonable BTC-derived price for ${symbol} from ${market}: $${priceUSD}`);
-                        // Continuer à chercher un prix plus raisonnable
-                      }
-                    }
-                  }
-                } catch (error) {
-                  console.warn(`Error fetching BTC market ${market} on attempt ${attempt}:`, error);
-                  
-                  if (attempt < this.MAX_RETRY_ATTEMPTS) {
-                    await this.sleep(this.RETRY_DELAY_MS);
-                  }
-                }
-              }
-            }
-          } else {
-            console.warn(`Could not get reliable BTC price for conversion: ${btcPrice}`);
-          }
+        
+        const data = await response.json() as TokenPriceResponse[];
+        
+        // Trouver le prix pour notre symbole
+        const tokenData = data.find(item => item.canonicalSymbol.toUpperCase() === symbolUpper);
+        
+        if (tokenData && typeof tokenData.priceUSD === 'number' && tokenData.priceUSD > 0) {
+          console.log(`Got price for ${symbolUpper} from LeftCurve API: $${tokenData.priceUSD}`);
+          return {
+            price: tokenData.priceUSD,
+            source: 'leftcurve_api'
+          };
+        } else {
+          console.warn(`Token ${symbolUpper} not found in API response or has invalid price`);
+        }
+      } catch (error) {
+        console.warn(`Error fetching price for ${symbolUpper} on attempt ${attempt}:`, error);
+        
+        if (attempt < this.MAX_RETRY_ATTEMPTS) {
+          await this.sleep(this.RETRY_DELAY_MS);
         }
       }
     }
     
-    // Fallback: try generic market formats if no known markets worked
-    console.log(`No known markets found or all yielded unreasonable prices for ${symbol}, trying generic market formats`);
-    
-    // 1. Essayer chaque format de marché
-    for (const formatTemplate of this.marketFormats) {
-      const market = formatTemplate.replace('{SYMBOL}', symbol);
-      
-      // Skip excluded market patterns
-      if (this.shouldExcludeMarket(market)) {
-        console.log(`Skipping excluded market pattern: ${market}`);
-        continue;
-      }
-      
-      // 2. Essayer plusieurs fois avec le même format si nécessaire
-      for (let attempt = 1; attempt <= this.MAX_RETRY_ATTEMPTS; attempt++) {
-        try {
-          const bboData = await this.bboService.fetchMarketBBO(config, market);
-          
-          // Pour la valorisation du portefeuille, nous utilisons le bid (prix de vente)
-          if (bboData?.bid) {
-            const price = parseFloat(bboData.bid);
-            if (!isNaN(price) && price > 0) {
-              console.log(`Got price for ${symbol} from ${market}: $${price} (attempt ${attempt})`);
-              
-              // Vérifier que le prix est dans une plage raisonnable
-              if (this.isPriceReasonable(symbolUpper, price)) {
-                return { price, source: market };
-              } else {
-                console.warn(`⚠️ Rejected unreasonable price for ${symbol} from ${market}: $${price}`);
-                // Continuer à chercher un prix plus raisonnable
-              }
-            }
-          }
-          
-          // Si le bid n'est pas disponible mais ask l'est, on peut utiliser ask avec une petite décote
-          if (!bboData?.bid && bboData?.ask) {
-            const askPrice = parseFloat(bboData.ask);
-            if (!isNaN(askPrice) && askPrice > 0) {
-              // Décote de 0.5% pour simuler un bid
-              const estimatedBid = askPrice * 0.995;
-              console.log(`Using adjusted ask price for ${symbol} from ${market}: $${estimatedBid} (from ask ${askPrice}, attempt ${attempt})`);
-              
-              // Vérifier que le prix estimé est dans une plage raisonnable
-              if (this.isPriceReasonable(symbolUpper, estimatedBid)) {
-                return { price: estimatedBid, source: `${market} (adjusted ask)` };
-              } else {
-                console.warn(`⚠️ Rejected unreasonable adjusted price for ${symbol} from ${market}: $${estimatedBid}`);
-                // Continuer à chercher un prix plus raisonnable
-              }
-            }
-          }
-        } catch (error) {
-          console.warn(`Error fetching ${market} on attempt ${attempt}:`, error);
-          
-          // Si ce n'est pas la dernière tentative, attendre avant de réessayer
-          if (attempt < this.MAX_RETRY_ATTEMPTS) {
-            await this.sleep(this.RETRY_DELAY_MS);
-          }
-        }
-      }
-    }
-
-    // 3. Aucun des formats n'a fonctionné ou n'a fourni un prix raisonnable
+    // Si on a épuisé toutes les tentatives sans succès
+    console.error(`Failed to get price for ${symbolUpper} after ${this.MAX_RETRY_ATTEMPTS} attempts`);
     return undefined;
   }
 


### PR DESCRIPTION
## Overview
This PR replaces the Paradex-based price fetching system with a direct integration to the LeftCurve API. This change makes the agent's price retrieval more robust and accurate for portfolio valuation and PnL calculations.

## Changes
- Removed BBOService dependency from Paradex
- Implemented direct API calls to LeftCurve price endpoint
- Added authentication with API key
- Created new interfaces for API responses
- Adjusted reasonable price ranges to reflect current market conditions
- Simplified code while maintaining important features like caching and price validation

## Benefits
- More reliable price source that won't fail due to missing support for certain tokens
- More accurate pricing data
- Simplified implementation with fewer points of failure
- Maintained backward compatibility with existing agent actions

## Testing
The service has been tested with sample requests and properly handles:
- Cache management
- Error handling and retry logic
- Price validation
- Authentication

## Configuration
The service now uses the LeftCurve API hosted at `http://13.38.118.193:8080` with proper API key authentication.